### PR TITLE
Add basic Flask event platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
-# get-together
-canvassing and events sharing platform
+# Get Together
+
+A simple political events platform built with Flask. It allows organisers to post canvassing sessions, fundraisers, and other events. Users can search events by location and see them in chronological order. The interface is styled in dark mode with a card layout.
+
+## Setup
+
+Create a virtual environment and install dependencies:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+Initialise the database:
+
+```bash
+python -c 'from app import db; db.create_all()'
+```
+
+Run the server:
+
+```bash
+flask run
+```
+
+## Features
+
+- Personal and organiser accounts
+- Create and list events by location
+- Chronological timeline of upcoming events
+- Simple location search to find events near you
+
+This is only a minimal prototype and does not include production security or a full feature set.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,102 @@
+from flask import Flask, render_template, redirect, url_for, request, flash
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import LoginManager, login_user, login_required, logout_user, current_user, UserMixin
+from werkzeug.security import generate_password_hash, check_password_hash
+from datetime import datetime
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'changeme'
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///events.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+db = SQLAlchemy(app)
+login_manager = LoginManager(app)
+login_manager.login_view = 'login'
+
+class User(UserMixin, db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(150), unique=True, nullable=False)
+    password = db.Column(db.String(150), nullable=False)
+    role = db.Column(db.String(20), nullable=False, default='personal')
+
+class Event(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200), nullable=False)
+    description = db.Column(db.Text, nullable=False)
+    location = db.Column(db.String(200), nullable=False)
+    date = db.Column(db.DateTime, nullable=False)
+    organiser_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    organiser = db.relationship('User', backref='events')
+
+@login_manager.user_loader
+def load_user(user_id):
+    return User.query.get(int(user_id))
+
+@app.route('/')
+def index():
+    location = request.args.get('location')
+    query = Event.query
+    if location:
+        query = query.filter(Event.location.ilike(f"%{location}%"))
+    events = query.order_by(Event.date.asc()).all()
+    return render_template('index.html', events=events)
+
+@app.route('/register', methods=['GET', 'POST'])
+def register():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        role = request.form.get('role', 'personal')
+        if User.query.filter_by(username=username).first():
+            flash('Username already exists')
+            return redirect(url_for('register'))
+        user = User(username=username, password=generate_password_hash(password), role=role)
+        db.session.add(user)
+        db.session.commit()
+        login_user(user)
+        return redirect(url_for('index'))
+    return render_template('register.html')
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        user = User.query.filter_by(username=username).first()
+        if user and check_password_hash(user.password, password):
+            login_user(user)
+            return redirect(url_for('index'))
+        flash('Invalid credentials')
+    return render_template('login.html')
+
+@app.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('index'))
+
+@app.route('/create', methods=['GET', 'POST'])
+@login_required
+def create_event():
+    if current_user.role != 'organiser':
+        flash('Only organisers can create events')
+        return redirect(url_for('index'))
+    if request.method == 'POST':
+        title = request.form['title']
+        description = request.form['description']
+        location = request.form['location']
+        date_str = request.form['date']
+        try:
+            date = datetime.fromisoformat(date_str)
+        except ValueError:
+            flash('Invalid date format')
+            return redirect(url_for('create_event'))
+        event = Event(title=title, description=description, location=location,
+                      date=date, organiser=current_user)
+        db.session.add(event)
+        db.session.commit()
+        return redirect(url_for('index'))
+    return render_template('create.html')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask==2.3.2
+Flask-Login==0.6.2
+Flask-SQLAlchemy==3.0.3
+Werkzeug==2.3.7

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,30 @@
+body {
+  background-color: #121212;
+  color: #eee;
+  font-family: Arial, sans-serif;
+}
+header nav a {
+  margin-right: 1em;
+  color: #80bfff;
+}
+.event-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1rem;
+}
+.card {
+  background-color: rgba(255,255,255,0.05);
+  padding: 1rem;
+  border-radius: 8px;
+  backdrop-filter: blur(5px);
+}
+input, textarea, select, button {
+  background: rgba(255,255,255,0.1);
+  color: #eee;
+  border: none;
+  padding: 0.5rem;
+  margin: 0.5rem 0;
+}
+button {
+  cursor: pointer;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Get Together</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="{{ url_for('index') }}">Home</a>
+      {% if current_user.is_authenticated %}
+        <span>Logged in as {{ current_user.username }}</span>
+        <a href="{{ url_for('logout') }}">Logout</a>
+        {% if current_user.role == 'organiser' %}
+        <a href="{{ url_for('create_event') }}">Create Event</a>
+        {% endif %}
+      {% else %}
+        <a href="{{ url_for('login') }}">Login</a>
+        <a href="{{ url_for('register') }}">Register</a>
+      {% endif %}
+    </nav>
+  </header>
+  <main>
+    {% with messages = get_flashed_messages() %}
+      {% if messages %}
+        <ul class="flashes">
+        {% for message in messages %}
+          <li>{{ message }}</li>
+        {% endfor %}
+        </ul>
+      {% endif %}
+    {% endwith %}
+    {% block content %}{% endblock %}
+  </main>
+</body>
+</html>

--- a/templates/create.html
+++ b/templates/create.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Create Event</h1>
+<form method="post">
+  <label>Title</label>
+  <input type="text" name="title" required>
+  <label>Description</label>
+  <textarea name="description" required></textarea>
+  <label>Location</label>
+  <input type="text" name="location" required>
+  <label>Date</label>
+  <input type="datetime-local" name="date" required>
+  <button type="submit">Create</button>
+</form>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Upcoming Events</h1>
+<form method="get" action="/">
+  <input type="text" name="location" placeholder="Search by location" value="{{ request.args.location }}"/>
+  <button type="submit">Search</button>
+</form>
+<div class="event-grid">
+{% for event in events %}
+  <div class="card">
+    <h3>{{ event.title }}</h3>
+    <p>{{ event.description }}</p>
+    <p><strong>Location:</strong> {{ event.location }}</p>
+    <p><strong>Date:</strong> {{ event.date.strftime('%Y-%m-%d %H:%M') }}</p>
+  </div>
+{% else %}
+  <p>No events found.</p>
+{% endfor %}
+</div>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Login</h1>
+<form method="post">
+  <label>Username</label>
+  <input type="text" name="username" required>
+  <label>Password</label>
+  <input type="password" name="password" required>
+  <button type="submit">Login</button>
+</form>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Register</h1>
+<form method="post">
+  <label>Username</label>
+  <input type="text" name="username" required>
+  <label>Password</label>
+  <input type="password" name="password" required>
+  <label>Role</label>
+  <select name="role">
+    <option value="personal">Personal</option>
+    <option value="organiser">Organiser</option>
+  </select>
+  <button type="submit">Register</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create Flask prototype for listing events
- allow login/register and event creation
- display events in dark mode card layout
- document setup instructions

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688531ec2238832bb390ad47fe5279e6